### PR TITLE
Allow filters to be used when listing devices and clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,17 @@ Current implementation focuses on core monitoring and basic device control funct
 
 The integration will automatically discover all devices and clients using API pagination to ensure complete coverage. Entities are created dynamically based on device capabilities (e.g., PoE sensors and buttons only appear for ports with PoE support, radio sensors only for devices with wireless radios).
 
+## Optional Configuration
+
+1. To configure options after initial setup, go to **Settings → Devices & Services → Unifi Network** → click the gear icon.
+
+2. **Optional Filters**: Configure filters to be used when enumerating devices and clients. See API documentation for [filter syntax](https://developer.ui.com/network/v10.0.162/filtering).
+   - **Devices Filter**: See API documentation for [filterable properties](https://developer.ui.com/network/v10.0.162/getadopteddeviceoverviewpage).
+     - Example: `and(not(ipAddress.eq('192.168.1.5')), not(ipAddress.eq('192.168.1.10')))` ignores 192.168.1.5 and 192.168.1.10
+   - **Clients Filter**: See API documentation for [filterable properties](https://developer.ui.com/network/v10.0.162/getconnectedclientoverviewpage).
+     - Example: `macAddress.eq('00:1a:2b:3c:4d:5e')` only tracks 00:1A:2B:3C:4D:5E
+     - Note: filter does not appear to match uppercase MAC addresses
+
 ## Notes and troubleshooting
 
 - **SSL Certificates**: If using self-signed certificates, disable SSL verification in the integration settings or ensure your Home Assistant host trusts the UniFi certificate.

--- a/custom_components/unifi_network/__init__.py
+++ b/custom_components/unifi_network/__init__.py
@@ -19,6 +19,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         enable_devices=entry.data.get("enable_devices", True),
         enable_clients=entry.data.get("enable_clients", True),
         verify_ssl=entry.data.get("verify_ssl", True),
+        devices_filter=entry.options.get("devices_filter"),
+        clients_filter=entry.options.get("clients_filter"),
     )
     await core.async_init()
 

--- a/custom_components/unifi_network/config_flow.py
+++ b/custom_components/unifi_network/config_flow.py
@@ -5,7 +5,13 @@ from typing import Any
 
 import voluptuous as vol
 from aiohttp import ClientError
-from homeassistant import config_entries
+from homeassistant.config_entries import (
+    ConfigEntry,
+    ConfigFlow,
+    ConfigFlowResult,
+    OptionsFlowWithReload,
+)
+from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import selector
 
@@ -17,10 +23,18 @@ from .const import DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 
-class UnifiNetworkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+class UnifiNetworkConfigFlow(ConfigFlow, domain=DOMAIN):
     """Config flow for Unifi Network integration."""
 
     VERSION = 1
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: ConfigEntry,
+    ) -> OptionsFlowHandler:
+        """Create the options flow."""
+        return OptionsFlowHandler()
 
     def __init__(self) -> None:
         self._base_url = None
@@ -147,4 +161,32 @@ class UnifiNetworkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="select_features", data_schema=schema, errors=errors
+        )
+
+
+class OptionsFlowHandler(OptionsFlowWithReload):
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Optional step: user sets filters for devices and clients."""
+
+        if user_input is not None:
+            return self.async_create_entry(data=user_input)
+
+        schema = vol.Schema(
+            {
+                vol.Optional("devices_filter"): selector.TextSelector(
+                    selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT)
+                ),
+                vol.Optional("clients_filter"): selector.TextSelector(
+                    selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT)
+                ),
+            }
+        )
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=self.add_suggested_values_to_schema(
+                schema, self.config_entry.options
+            ),
         )

--- a/custom_components/unifi_network/coordinator.py
+++ b/custom_components/unifi_network/coordinator.py
@@ -17,6 +17,7 @@ from .api_client.api.uni_fi_devices import (
     get_adopted_device_latest_statistics,
     get_adopted_device_overview_page,
 )
+from .api_client.types import UNSET
 from .api_helpers import fetch_all_pages
 from .const import DEFAULT_UPDATE_INTERVAL, DOMAIN
 from .unifi_client import UnifiClient
@@ -33,6 +34,7 @@ class UnifiCoordinator(DataUpdateCoordinator):
         hass: HomeAssistant,
         client: Client,
         site_id: str,
+        filter_: str | None,
         name: str,
         update_method: Callable[[], Coroutine[Any, Any, Any]],
     ):
@@ -45,6 +47,10 @@ class UnifiCoordinator(DataUpdateCoordinator):
         )
         self.client = client
         self.site_id = site_id
+        if filter_ is None:
+            self.filter_ = UNSET
+        else:
+            self.filter_ = filter_
         self._update_method = update_method
 
     async def _async_update_data(self) -> dict[str, Any]:
@@ -60,11 +66,18 @@ class UnifiDeviceCoordinator(UnifiCoordinator):
     in a dict mapping device_id to UnifiDevice.
     """
 
-    def __init__(self, hass: HomeAssistant, client: Client, site_id: str):
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        client: Client,
+        site_id: str,
+        filter_: str | None = None,
+    ):
         super().__init__(
             hass=hass,
             client=client,
             site_id=site_id,
+            filter_=filter_,
             name="devices",
             update_method=self._fetch_and_merge,
         )
@@ -82,6 +95,7 @@ class UnifiDeviceCoordinator(UnifiCoordinator):
                 get_adopted_device_overview_page.asyncio_detailed,
                 client=self.client,
                 site_id=self.site_id,
+                filter_=self.filter_,
             )
 
             # Prepare tasks to fetch statistics and details for each device concurrently
@@ -160,11 +174,18 @@ class UnifiClientCoordinator(UnifiCoordinator):
     in a dict mapping client_id to UnifiClient.
     """
 
-    def __init__(self, hass: HomeAssistant, client: Client, site_id: str):
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        client: Client,
+        site_id: str,
+        filter_: str | None = None,
+    ):
         super().__init__(
             hass=hass,
             client=client,
             site_id=site_id,
+            filter_=filter_,
             name="clients",
             update_method=self._fetch_and_merge,
         )
@@ -183,6 +204,7 @@ class UnifiClientCoordinator(UnifiCoordinator):
                 get_connected_client_overview_page.asyncio_detailed,
                 client=self.client,
                 site_id=self.site_id,
+                filter_=self.filter_,
             )
 
             # Prepare tasks to fetch details for each client concurrently

--- a/custom_components/unifi_network/core.py
+++ b/custom_components/unifi_network/core.py
@@ -21,6 +21,8 @@ class UnifiNetworkCore:
         enable_devices: bool = True,
         enable_clients: bool = True,
         verify_ssl: bool = True,
+        devices_filter: str | None = None,
+        clients_filter: str | None = None,
     ) -> None:
         """Initialize Unifi Network core."""
         self.hass = hass
@@ -47,12 +49,12 @@ class UnifiNetworkCore:
 
         if enable_devices:
             self.device_coordinator = UnifiDeviceCoordinator(
-                hass=hass, client=self.client, site_id=site_id
+                hass=hass, client=self.client, site_id=site_id, filter_=devices_filter
             )
 
         if enable_clients:
             self.client_coordinator = UnifiClientCoordinator(
-                hass=hass, client=self.client, site_id=site_id
+                hass=hass, client=self.client, site_id=site_id, filter_=clients_filter
             )
 
     async def async_init(self) -> None:

--- a/custom_components/unifi_network/strings.json
+++ b/custom_components/unifi_network/strings.json
@@ -45,6 +45,22 @@
         "no_features_selected": "Please select at least one feature to enable."
       }
     },
+    "options": {
+      "step": {
+        "init": {
+          "title": "Optional Filters",
+          "description": "See API documentation for filter syntax and filterable properties",
+          "data": {
+            "devices_filter": "Devices Filter",
+            "clients_filter": "Clients Filter"
+          },
+          "data_description": {
+            "devices_filter": "e.g., and(not(ipAddress.eq('192.168.1.5')), not(ipAddress.eq('192.168.1.10'))) ignores 192.168.1.5 and 192.168.1.10",
+            "clients_filter": "e.g., macAddress.eq('00:1a:2b:3c:4d:5e') only tracks 00:1A:2B:3C:4D:5E"
+          }
+        }
+      }
+    },
     "services": {
       "remove_stale_clients": {
         "name": "Remove stale Unifi clients",

--- a/custom_components/unifi_network/translations/en.json
+++ b/custom_components/unifi_network/translations/en.json
@@ -45,6 +45,22 @@
       "no_features_selected": "Please select at least one feature to enable."
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Optional Filters",
+        "description": "See API documentation for filter syntax and filterable properties",
+        "data": {
+          "devices_filter": "Devices Filter",
+          "clients_filter": "Clients Filter"
+        },
+        "data_description": {
+          "devices_filter": "e.g., and(not(ipAddress.eq('192.168.1.5')), not(ipAddress.eq('192.168.1.10'))) ignores 192.168.1.5 and 192.168.1.10",
+          "clients_filter": "e.g., macAddress.eq('00:1a:2b:3c:4d:5e') only tracks 00:1A:2B:3C:4D:5E"
+        }
+      }
+    }
+  },
   "entity": {
     "sensor": {
       "device_state": { "name": "State" },

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -8,6 +8,7 @@ import pytest
 
 # Import conftest to set up mocks
 import tests.conftest
+from custom_components.unifi_network.api_client.types import UNSET
 
 # Now import the modules after mocks are set up
 from custom_components.unifi_network.coordinator import (
@@ -227,6 +228,46 @@ class TestUnifiDeviceCoordinator:
         result = device_coordinator.get_device("device-123")
         assert result is None
 
+    def test_default_filter_becomes_unset(self, mock_hass, mock_api_client):
+        """Test that filter_ defaults to UNSET when omitted."""
+        coord = UnifiDeviceCoordinator(mock_hass, mock_api_client, "test-site")
+        assert coord.filter_ is UNSET
+
+    def test_none_filter_becomes_unset(self, mock_hass, mock_api_client):
+        """Test that filter_=None is converted to UNSET."""
+        coord = UnifiDeviceCoordinator(
+            mock_hass, mock_api_client, "test-site", filter_=None
+        )
+        assert coord.filter_ is UNSET
+
+    def test_string_filter_preserved(self, mock_hass, mock_api_client):
+        """Test that a string filter value is stored as-is."""
+        coord = UnifiDeviceCoordinator(
+            mock_hass,
+            mock_api_client,
+            "test-site",
+            filter_="ipAddress.eq('192.168.1.1')",
+        )
+        assert coord.filter_ == "ipAddress.eq('192.168.1.1')"
+
+    async def test_filter_passed_to_fetch_all_pages(self, mock_hass, mock_api_client):
+        """Test that filter_ is passed through to fetch_all_pages."""
+        coord = UnifiDeviceCoordinator(
+            mock_hass,
+            mock_api_client,
+            "test-site",
+            filter_="ipAddress.eq('192.168.1.1')",
+        )
+
+        with patch(
+            "custom_components.unifi_network.coordinator.fetch_all_pages",
+            return_value=[],
+        ) as mock_fetch:
+            await coord._fetch_and_merge()
+
+        mock_fetch.assert_called_once()
+        assert mock_fetch.call_args.kwargs["filter_"] == "ipAddress.eq('192.168.1.1')"
+
 
 class TestUnifiClientCoordinator:
     """Test the UniFi Client coordinator."""
@@ -342,3 +383,45 @@ class TestUnifiClientCoordinator:
 
         result = client_coordinator.get_client("nonexistent")
         assert result is None
+
+    def test_default_filter_becomes_unset(self, mock_hass, mock_api_client):
+        """Test that filter_ defaults to UNSET when omitted."""
+        coord = UnifiClientCoordinator(mock_hass, mock_api_client, "test-site")
+        assert coord.filter_ is UNSET
+
+    def test_none_filter_becomes_unset(self, mock_hass, mock_api_client):
+        """Test that filter_=None is converted to UNSET."""
+        coord = UnifiClientCoordinator(
+            mock_hass, mock_api_client, "test-site", filter_=None
+        )
+        assert coord.filter_ is UNSET
+
+    def test_string_filter_preserved(self, mock_hass, mock_api_client):
+        """Test that a string filter value is stored as-is."""
+        coord = UnifiClientCoordinator(
+            mock_hass,
+            mock_api_client,
+            "test-site",
+            filter_="not(ipAddress.eq('192.168.1.1'))",
+        )
+        assert coord.filter_ == "not(ipAddress.eq('192.168.1.1'))"
+
+    async def test_filter_passed_to_fetch_all_pages(self, mock_hass, mock_api_client):
+        """Test that filter_ is passed through to fetch_all_pages."""
+        coord = UnifiClientCoordinator(
+            mock_hass,
+            mock_api_client,
+            "test-site",
+            filter_="not(ipAddress.eq('192.168.1.1'))",
+        )
+
+        with patch(
+            "custom_components.unifi_network.coordinator.fetch_all_pages",
+            return_value=[],
+        ) as mock_fetch:
+            await coord._fetch_and_merge()
+
+        mock_fetch.assert_called_once()
+        assert (
+            mock_fetch.call_args.kwargs["filter_"] == "not(ipAddress.eq('192.168.1.1'))"
+        )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -202,6 +202,92 @@ async def test_init_without_coordinators(
 
 @patch("custom_components.unifi_network.core.create_async_httpx_client")
 @patch("custom_components.unifi_network.core.Client")
+@patch("custom_components.unifi_network.core.UnifiDeviceCoordinator")
+@patch("custom_components.unifi_network.core.UnifiClientCoordinator")
+@pytest.mark.asyncio
+async def test_init_passes_filters_to_coordinators(
+    mock_client_coordinator,
+    mock_device_coordinator,
+    mock_client_class,
+    mock_create_client,
+    mock_hass,
+):
+    """Test that filter parameters are passed through to coordinators."""
+    mock_client = Mock()
+    mock_httpx_client = Mock()
+    mock_httpx_client.headers = Mock()
+    mock_client_class.return_value = mock_client
+    mock_create_client.return_value = mock_httpx_client
+
+    mock_device_coordinator.return_value = AsyncMock()
+    mock_client_coordinator.return_value = AsyncMock()
+
+    UnifiNetworkCore(
+        hass=mock_hass,
+        base_url="https://unifi.example.com",
+        site_id="default",
+        api_key="test-key",
+        enable_devices=True,
+        enable_clients=True,
+        verify_ssl=True,
+        devices_filter="ipAddress.eq('192.168.1.1')",
+        clients_filter="not(ipAddress.eq('192.168.1.1'))",
+    )
+
+    # Verify device coordinator was created with the devices filter
+    mock_device_coordinator.assert_called_once()
+    assert (
+        mock_device_coordinator.call_args.kwargs["filter_"]
+        == "ipAddress.eq('192.168.1.1')"
+    )
+
+    # Verify client coordinator was created with the clients filter
+    mock_client_coordinator.assert_called_once()
+    assert (
+        mock_client_coordinator.call_args.kwargs["filter_"]
+        == "not(ipAddress.eq('192.168.1.1'))"
+    )
+
+
+@patch("custom_components.unifi_network.core.create_async_httpx_client")
+@patch("custom_components.unifi_network.core.Client")
+@patch("custom_components.unifi_network.core.UnifiDeviceCoordinator")
+@patch("custom_components.unifi_network.core.UnifiClientCoordinator")
+@pytest.mark.asyncio
+async def test_init_passes_none_filters_by_default(
+    mock_client_coordinator,
+    mock_device_coordinator,
+    mock_client_class,
+    mock_create_client,
+    mock_hass,
+):
+    """Test that filter parameters default to None when not provided."""
+    mock_client = Mock()
+    mock_httpx_client = Mock()
+    mock_httpx_client.headers = Mock()
+    mock_client_class.return_value = mock_client
+    mock_create_client.return_value = mock_httpx_client
+
+    mock_device_coordinator.return_value = AsyncMock()
+    mock_client_coordinator.return_value = AsyncMock()
+
+    UnifiNetworkCore(
+        hass=mock_hass,
+        base_url="https://unifi.example.com",
+        site_id="default",
+        api_key="test-key",
+        enable_devices=True,
+        enable_clients=True,
+        verify_ssl=True,
+    )
+
+    # Verify coordinators were created with filter_=None (the default)
+    assert mock_device_coordinator.call_args.kwargs["filter_"] is None
+    assert mock_client_coordinator.call_args.kwargs["filter_"] is None
+
+
+@patch("custom_components.unifi_network.core.create_async_httpx_client")
+@patch("custom_components.unifi_network.core.Client")
 @pytest.mark.asyncio
 async def test_init_without_api_key(
     mock_client_class,


### PR DESCRIPTION
I only need device trackers for a handful of devices for presence detection, so I added the ability to configure filters when listing clients. For parity, I also added support for filtering devices. Filters are configured through an options flow after initial setup.