### PR TITLE
Add uplink device for clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,18 @@ Home Assistant custom integration for UniFi Network that uses UniFi's official I
 
 #### Device Trackers
 
-- **UniFi Client Tracker**: Reports `home` when client is currently connected, `not_home` otherwise. Attributes include IP address, MAC address, last seen timestamp, connected at timestamp (when available), and `source_type=router`. Automatically created for all discovered clients when client tracking is enabled.
+- **UniFi Client Tracker**: Reports `home` when client is currently connected, `not_home` otherwise. 
+  
+  Attributes include:
+  - `mac` — client MAC address
+  - `ip` — client IP address
+  - `last_seen` — timestamp of last observed connection
+  - `connected_at` — connection start timestamp (when available)
+  - `uplink_mac` — MAC address of the UniFi device the client is connected through (`null` when devices feature is disabled or uplink is unresolved)
+  - `uplink_device_name` — name of the UniFi device the client is connected through (`null` when devices feature is disabled or uplink is unresolved)
+  - `source_type=router`
+
+  Automatically created for all discovered clients when client tracking is enabled. The `uplink_mac` and `uplink_device_name` attributes are populated when both client tracking and device monitoring are enabled simultaneously.
 
 #### Device Sensors
 

--- a/custom_components/unifi_network/device_tracker.py
+++ b/custom_components/unifi_network/device_tracker.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .api_client.types import UNSET
 from .const import DOMAIN
-from .coordinator import UnifiClientCoordinator
+from .coordinator import UnifiClientCoordinator, UnifiDeviceCoordinator
 
 
 async def async_setup_entry(
@@ -19,7 +19,8 @@ async def async_setup_entry(
 ) -> None:
     """Set up Unifi device_tracker platform."""
     core = hass.data[DOMAIN][entry.entry_id]
-    coordinator = core.client_coordinator
+    coordinator: UnifiClientCoordinator = core.client_coordinator
+    device_coordinator: UnifiDeviceCoordinator | None = core.device_coordinator
 
     # Keep track of client IDs that already got entities
     tracked_clients: set[str] = set()
@@ -35,7 +36,9 @@ async def async_setup_entry(
             if client_id in tracked_clients:
                 continue
 
-            new_entities.append(UnifiClientTracker(coordinator, client_id))
+            new_entities.append(
+                UnifiClientTracker(coordinator, client_id, device_coordinator)
+            )
             tracked_clients.add(client_id)
 
         if new_entities:
@@ -56,9 +59,15 @@ class UnifiClientTracker(CoordinatorEntity, TrackerEntity):
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_source_type = SourceType.ROUTER
 
-    def __init__(self, coordinator: UnifiClientCoordinator, client_id: str) -> None:
+    def __init__(
+        self,
+        coordinator: UnifiClientCoordinator,
+        client_id: str,
+        device_coordinator: UnifiDeviceCoordinator | None,
+    ) -> None:
         super().__init__(coordinator)
         self.client_id = client_id
+        self._device_coordinator = device_coordinator
         self._attr_unique_id = f"unifi_client_{client_id}_device_tracker"
 
     @property
@@ -94,7 +103,15 @@ class UnifiClientTracker(CoordinatorEntity, TrackerEntity):
             "mac": client.mac,
             "ip": client.ip,
             "last_seen": client.last_seen,
+            "uplink_mac": None,
+            "uplink_device_name": None,
         }
+
+        if self._device_coordinator and client.uplink_device_id:
+            uplink_device = self._device_coordinator.get_device(client.uplink_device_id)
+            if uplink_device:
+                attrs["uplink_mac"] = uplink_device.mac
+                attrs["uplink_device_name"] = uplink_device.name
 
         connected_at = getattr(client.overview, "connected_at", None)
         if connected_at is not None and connected_at is not UNSET:

--- a/custom_components/unifi_network/unifi_client.py
+++ b/custom_components/unifi_network/unifi_client.py
@@ -59,6 +59,22 @@ class UnifiClient:
         return None
 
     @property
+    def uplink_device_id(self) -> str | None:
+        """Return the uplink device ID for this client, or None if unavailable."""
+        # Prefer value from overview, then fall back to details if present.
+        for src in (self.overview, self.details):
+            if not src:
+                continue
+            additional = getattr(src, "additional_properties", None)
+            if isinstance(additional, dict):
+                uplink_device_id = additional.get("uplinkDeviceId")
+                if uplink_device_id is not None and isinstance(uplink_device_id, Unset):
+                    return None
+                if uplink_device_id:
+                    return str(uplink_device_id)
+        return None
+
+    @property
     def device_info(self) -> DeviceInfo:
         """Return DeviceInfo for this UniFi client with vendor as manufacturer."""
         identifiers = {(DOMAIN, self.id)}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,6 +90,23 @@ class UpdateFailed(Exception):
     """Mock UpdateFailed exception."""
 
 
+class MockCoordinatorEntity:
+    """Mock CoordinatorEntity base class."""
+
+    def __init__(self, coordinator):
+        self.coordinator = coordinator
+
+
+class MockTrackerEntity:
+    """Mock TrackerEntity base class."""
+
+
+class MockSourceType:
+    """Mock SourceType enum-like container."""
+
+    ROUTER = "router"
+
+
 # Mock config_entries module
 config_entries = Mock()
 config_entries.ConfigFlow = MockConfigFlow
@@ -121,9 +138,14 @@ entity_platform.AddEntitiesCallback = Mock()
 
 # Mock update coordinator
 update_coordinator = Mock()
-update_coordinator.CoordinatorEntity = Mock()
+update_coordinator.CoordinatorEntity = MockCoordinatorEntity
 update_coordinator.DataUpdateCoordinator = MockUpdateCoordinator
 update_coordinator.UpdateFailed = UpdateFailed
+
+# Mock device tracker components
+device_tracker = Mock()
+device_tracker.TrackerEntity = MockTrackerEntity
+device_tracker.SourceType = MockSourceType
 
 # Mock httpx_client helper
 httpx_client = Mock()
@@ -135,6 +157,7 @@ homeassistant = Mock()
 homeassistant.config_entries = config_entries
 homeassistant.core.HomeAssistant = MockHomeAssistant
 homeassistant.components.sensor = sensor
+homeassistant.components.device_tracker = device_tracker
 homeassistant.const = const
 homeassistant.helpers.entity = entity
 homeassistant.helpers.entity_platform = entity_platform
@@ -150,6 +173,7 @@ sys.modules["homeassistant.const"] = const
 sys.modules["homeassistant.data_entry_flow"] = data_entry_flow
 sys.modules["homeassistant.components"] = Mock()
 sys.modules["homeassistant.components.sensor"] = sensor
+sys.modules["homeassistant.components.device_tracker"] = device_tracker
 sys.modules["homeassistant.helpers"] = Mock()
 sys.modules["homeassistant.helpers.entity"] = entity
 sys.modules["homeassistant.helpers.entity_platform"] = entity_platform

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -1,0 +1,140 @@
+"""Tests for device tracker client attributes."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import Mock
+
+from custom_components.unifi_network.device_tracker import UnifiClientTracker
+
+
+class TestUnifiClientTracker:
+    """Test client tracker attribute behavior."""
+
+    def test_extra_state_attributes_with_resolved_uplink_device(self):
+        """Expose resolved uplink MAC and name when lookup succeeds."""
+        client_id = "client_123"
+        now = datetime(2026, 1, 1, tzinfo=UTC)
+
+        client = Mock()
+        client.mac = "aa:bb:cc:dd:ee:ff"
+        client.ip = "192.168.1.10"
+        client.last_seen = now
+        client.uplink_device_id = "device_1"
+        client.overview = Mock()
+        client.overview.connected_at = "2026-01-01T00:00:00+00:00"
+
+        client_coordinator = Mock()
+        client_coordinator.data = {client_id: client}
+        client_coordinator.get_client.return_value = client
+
+        uplink_device = Mock()
+        uplink_device.mac = "11:22:33:44:55:66"
+        uplink_device.name = "Core Switch"
+
+        device_coordinator = Mock()
+        device_coordinator.get_device.return_value = uplink_device
+
+        tracker = UnifiClientTracker(client_coordinator, client_id, device_coordinator)
+
+        attrs = tracker.extra_state_attributes
+
+        assert attrs is not None
+        assert attrs["mac"] == "aa:bb:cc:dd:ee:ff"
+        assert attrs["ip"] == "192.168.1.10"
+        assert attrs["last_seen"] == now
+        assert attrs["connected_at"] == "2026-01-01T00:00:00+00:00"
+        assert attrs["uplink_mac"] == "11:22:33:44:55:66"
+        assert attrs["uplink_device_name"] == "Core Switch"
+        device_coordinator.get_device.assert_called_once_with("device_1")
+
+    def test_extra_state_attributes_without_device_coordinator(self):
+        """Keep uplink keys with None values when devices are disabled."""
+        client_id = "client_123"
+
+        client = Mock()
+        client.mac = "aa:bb:cc:dd:ee:ff"
+        client.ip = "192.168.1.10"
+        client.last_seen = None
+        client.uplink_device_id = "device_1"
+        client.overview = Mock()
+        client.overview.connected_at = None
+
+        client_coordinator = Mock()
+        client_coordinator.data = {client_id: client}
+        client_coordinator.get_client.return_value = client
+
+        tracker = UnifiClientTracker(client_coordinator, client_id, None)
+
+        attrs = tracker.extra_state_attributes
+
+        assert attrs is not None
+        assert attrs["uplink_mac"] is None
+        assert attrs["uplink_device_name"] is None
+
+    def test_extra_state_attributes_with_unknown_uplink_device(self):
+        """Keep uplink keys with None values when lookup misses."""
+        client_id = "client_123"
+
+        client = Mock()
+        client.mac = "aa:bb:cc:dd:ee:ff"
+        client.ip = "192.168.1.10"
+        client.last_seen = None
+        client.uplink_device_id = "missing-device"
+        client.overview = Mock()
+        client.overview.connected_at = None
+
+        client_coordinator = Mock()
+        client_coordinator.data = {client_id: client}
+        client_coordinator.get_client.return_value = client
+
+        device_coordinator = Mock()
+        device_coordinator.get_device.return_value = None
+
+        tracker = UnifiClientTracker(client_coordinator, client_id, device_coordinator)
+
+        attrs = tracker.extra_state_attributes
+
+        assert attrs is not None
+        assert attrs["uplink_mac"] is None
+        assert attrs["uplink_device_name"] is None
+        device_coordinator.get_device.assert_called_once_with("missing-device")
+
+    def test_extra_state_attributes_with_missing_uplink_device_id(self):
+        """Keep uplink keys with None values when client has no uplink ID."""
+        client_id = "client_123"
+
+        client = Mock()
+        client.mac = "aa:bb:cc:dd:ee:ff"
+        client.ip = "192.168.1.10"
+        client.last_seen = None
+        client.uplink_device_id = None
+        client.overview = Mock()
+        client.overview.connected_at = None
+
+        client_coordinator = Mock()
+        client_coordinator.data = {client_id: client}
+        client_coordinator.get_client.return_value = client
+
+        device_coordinator = Mock()
+
+        tracker = UnifiClientTracker(client_coordinator, client_id, device_coordinator)
+
+        attrs = tracker.extra_state_attributes
+
+        assert attrs is not None
+        assert attrs["uplink_mac"] is None
+        assert attrs["uplink_device_name"] is None
+        device_coordinator.get_device.assert_not_called()
+
+    def test_extra_state_attributes_returns_none_when_client_missing(self):
+        """Return None attributes when coordinator cannot resolve client."""
+        client_id = "client_123"
+
+        client_coordinator = Mock()
+        client_coordinator.data = {}
+        client_coordinator.get_client.return_value = None
+
+        tracker = UnifiClientTracker(client_coordinator, client_id, None)
+
+        assert tracker.extra_state_attributes is None

--- a/tests/test_unifi_client.py
+++ b/tests/test_unifi_client.py
@@ -139,6 +139,70 @@ class TestUnifiClient:
 
         assert client.mac is None
 
+    def test_client_uplink_device_id_from_overview(self):
+        """Test uplink device ID from overview additional_properties."""
+        mock_overview = MagicMock()
+        mock_overview.id = "client_123"
+        mock_overview.additional_properties = {
+            "uplinkDeviceId": "device-overview-123",
+        }
+
+        client = UnifiClient(overview=mock_overview, details=None)
+
+        assert client.uplink_device_id == "device-overview-123"
+
+    def test_client_uplink_device_id_from_details(self):
+        """Test uplink device ID from details when missing in overview."""
+        mock_overview = MagicMock()
+        mock_overview.id = "client_123"
+        mock_overview.additional_properties = {}
+
+        mock_details = MagicMock()
+        mock_details.additional_properties = {
+            "uplinkDeviceId": "device-details-456",
+        }
+
+        client = UnifiClient(overview=mock_overview, details=mock_details)
+
+        assert client.uplink_device_id == "device-details-456"
+
+    def test_client_uplink_device_id_prioritizes_overview(self):
+        """Test overview uplink device ID is preferred over details."""
+        mock_overview = MagicMock()
+        mock_overview.id = "client_123"
+        mock_overview.additional_properties = {
+            "uplinkDeviceId": "device-overview-priority",
+        }
+
+        mock_details = MagicMock()
+        mock_details.additional_properties = {
+            "uplinkDeviceId": "device-details-fallback",
+        }
+
+        client = UnifiClient(overview=mock_overview, details=mock_details)
+
+        assert client.uplink_device_id == "device-overview-priority"
+
+    def test_client_uplink_device_id_with_unset(self):
+        """Test uplink device ID property when value is Unset."""
+        mock_overview = MagicMock()
+        mock_overview.id = "client_123"
+        mock_overview.additional_properties = {"uplinkDeviceId": Unset()}
+
+        client = UnifiClient(overview=mock_overview, details=None)
+
+        assert client.uplink_device_id is None
+
+    def test_client_uplink_device_id_missing(self):
+        """Test uplink device ID property when field is missing."""
+        mock_overview = MagicMock()
+        mock_overview.id = "client_123"
+        mock_overview.additional_properties = {}
+
+        client = UnifiClient(overview=mock_overview, details=None)
+
+        assert client.uplink_device_id is None
+
     def test_device_info_with_complete_data(self):
         """Test DeviceInfo generation with complete client data."""
         mock_overview = MagicMock()


### PR DESCRIPTION
Add uplink device name and mac address in client device tracker attributes

  - `uplink_mac` — MAC address of the UniFi device the client is connected through (`null` when devices feature is disabled or uplink is unresolved)
  - `uplink_device_name` — name of the UniFi device the client is connected through (`null` when devices feature is disabled or uplink is unresolved)